### PR TITLE
feat: Add autocomplete attr to country and region

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ whiteList | no | [] | array | Fill this array with capitalized short codes of th
 blackList | no | [] | array | Fill this array with capitalized short codes of the countries you want to remove from dropdown list. ex: ['US'] 
 className | no | '' | string | Class name ex: `form-control`
 placeholder | no | 'Select Country' | string | The placeholder text for country select
+autocomplete | no | false | boolean | Set to true to enable browser to automatically fill out the country.
 shortCodeDropdown | no | false | boolean | Use this to have dropdown text display as short codes
 usei18n | no | true | boolean | Set to false if using i18n and want to disable for this component
 disablePlaceholder | no | false | boolean | Set to true to make placeholder non-selectable
@@ -74,6 +75,7 @@ countryName | no | false | boolean | Set this to true if you are setting it to t
 regionName | no | false | boolean | Set this to true if you want the v-model to output full region names instead of the default abbreviations.
 className | no | '' | string | Class name ex: `form-control`
 placeholder | no | 'Select Region' | string | The placeholder text for region select
+autocomplete | no | false | boolean | Set to true to enable browser to automatically fill out the region.
 shortCodeDropdown | no | false | boolean | Use this to have dropdown text display as short codes
 usei18n | no | true | boolean | Set to false if using i18n and want to disable for this component
 disablePlaceholder | no | false | boolean | Set to true to make placeholder non-selectable, this will cause regions to set to first available when switching countries

--- a/src/components/country-select.vue
+++ b/src/components/country-select.vue
@@ -10,6 +10,7 @@
       blackList: Array,
       className: String,
       shortCodeDropdown: Boolean,
+      autocomplete: Boolean,
       topCountry: {
         type: String,
         default: ""
@@ -93,6 +94,10 @@
       },
       valueType() {
         return this.countryName ? 'countryName' : 'countryShortCode'
+      },
+      autocompleteAttr() {
+        const autocompleteType = (showsFullCountryName) => showsFullCountryName ? "country-name" : "country";
+        return this.autocomplete ? autocompleteType(this.countryName) : "off";
       }
     },
     methods: {
@@ -117,7 +122,7 @@
 </script>
 
 <template>
-  <select @change="onChange($event.target.value)" :class="className">
+  <select @change="onChange($event.target.value)" :class="className" :autocomplete="autocompleteAttr">
     <option value="" v-if="!disablePlaceholder && !removePlaceholder">{{ placeholder }}</option>
     <option value="" v-if="disablePlaceholder && !removePlaceholder" disabled selected>{{ placeholder }}</option>
     <option v-if="topCountry" :value="firstCountry" :selected="country === firstCountry">{{topCountryName()}}</option>

--- a/src/components/region-select.vue
+++ b/src/components/region-select.vue
@@ -10,6 +10,7 @@
       regionName: Boolean,
       className: String,
       shortCodeDropdown: Boolean,
+      autocomplete: Boolean,
       placeholder: {
         type: String,
         default: 'Select Region'
@@ -54,6 +55,9 @@
       },
       valueType() {
         return this.regionName ? 'name' : 'shortCode'
+      },
+      autocompleteAttr() {
+        return this.autocomplete ? "address-level1" : "off";
       }
     },
     methods: {
@@ -105,7 +109,7 @@
 </script>
 
 <template>
-  <select @change="onChange($event.target.value)" :class="className">
+  <select @change="onChange($event.target.value)" :class="className" :autocomplete="autocompleteAttr">
     <option v-if="!disablePlaceholder && !removePlaceholder" value="">{{ placeholder }}</option>
     <option v-if="disablePlaceholder && !removePlaceholder" value="" disabled selected>{{ placeholder }}</option>
     <option v-for="(place, index) in shownRegions" v-bind:key="index" :value="place[valueType]" :selected="region === place[valueType]">{{shortCodeDropdown ? place.shortCode : place.name}}</option>


### PR DESCRIPTION
This PR adds the ability to enable autocomplete for the country and region components, according to the [autocomplete spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).

If the autocomplete prop is set to `true`, it adds:
- For country-select: Autocomplete will be set to `"off"` or `"country"`. (Or `"country-name"`, if `countryName` is `true`).
- For region-select: Autocomplete will be set to `"off` or `"address-level1"`.

I've also updated README.MD to include the autocomplete property.